### PR TITLE
refator: time_sleep 로직 리팩토링

### DIFF
--- a/pintos/devices/timer.c
+++ b/pintos/devices/timer.c
@@ -23,22 +23,11 @@ static int64_t ticks;
 /* Number of loops per timer tick.
    Initialized by timer_calibrate(). */
 static unsigned loops_per_tick;
-static struct list sleep_list;
-
-
-/* Thread element */
-struct thread_elem {
-   struct list_elem elem;
-   struct thread* val;
-   int64_t ticks;
-};
 
 static intr_handler_func timer_interrupt;
 static bool too_many_loops (unsigned loops);
 static void busy_wait (int64_t loops);
 static void real_time_sleep (int64_t num, int32_t denom);
-
-bool thread_tick_less(const struct list_elem *a_, const struct list_elem *b_, void *aux);
 
 /* Sets up the 8254 Programmable Interval Timer (PIT) to
    interrupt PIT_FREQ times per second, and registers the
@@ -54,8 +43,6 @@ timer_init (void) {
 	outb (0x40, count >> 8);
 
 	intr_register_ext (0x20, timer_interrupt, "8254 Timer");
-
-	list_init(&sleep_list);
 }
 
 /* Calibrates loops_per_tick, used to implement brief delays. */
@@ -104,17 +91,14 @@ timer_elapsed (int64_t then) {
 void
 timer_sleep (int64_t ticks) {
 	int64_t start = timer_ticks ();
+	int64_t wake_time = start + ticks;
 
 	ASSERT (intr_get_level () == INTR_ON);
-	struct thread_elem te;
-	te.ticks = ticks + start;
-	te.val = thread_current();
 
-	enum intr_level old_level = intr_disable();
-	list_insert_ordered(&sleep_list, (struct list_elem *)&te, thread_tick_less, NULL);
-	
-	thread_block();
-	intr_set_level(old_level);
+	if (ticks <= 0)
+		return;
+
+	wait_thread(wake_time);
 }
 
 /* Suspends execution for approximately MS milliseconds. */
@@ -146,14 +130,8 @@ static void
 timer_interrupt (struct intr_frame *args UNUSED) {
 	ticks++;
 	thread_tick ();
-	struct thread_elem *front = NULL;
-	while(!list_empty(&sleep_list) &&
-	 (front = list_entry(list_front(&sleep_list), struct thread_elem, elem)) &&
-	 front->val->status == THREAD_BLOCKED &&
-	 front->ticks <= ticks) {
-		list_pop_front(&sleep_list);
-		thread_unblock(front->val);
-	}
+	
+	check_block_list(ticks);
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer
@@ -211,13 +189,4 @@ real_time_sleep (int64_t num, int32_t denom) {
 		ASSERT (denom % 1000 == 0);
 		busy_wait (loops_per_tick * num / 1000 * TIMER_FREQ / (denom / 1000));
 	}
-}
-
-
-bool thread_tick_less(const struct list_elem *a_, const struct list_elem *b_, void *aux) {
-	const struct thread_elem *a = list_entry (a_, struct thread_elem, elem);
-	const struct thread_elem *b = list_entry (b_, struct thread_elem, elem);
-	struct thread_elem *front = NULL;
-
-	return a->ticks < b->ticks;
 }

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -91,6 +91,7 @@ struct thread {
 	enum thread_status status;          /* Thread state. */
 	char name[16];                      /* Name (for debugging purposes). */
 	int priority;                       /* Priority. */
+	int64_t wake_tick;
 
 	/* Shared between thread.c and synch.c. */
 	struct list_elem elem;              /* List element. */
@@ -142,5 +143,9 @@ int thread_get_recent_cpu (void);
 int thread_get_load_avg (void);
 
 void do_iret (struct intr_frame *tf);
+
+/* alram clock 과제 함수 정의 */
+void wait_thread(int64_t ticks);
+void check_block_list();
 
 #endif /* threads/thread.h */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -28,6 +28,9 @@
    that are ready to run but not actually running. */
 static struct list ready_list;
 
+/* List of processes in THREAD_BLOCKED state */
+static struct list block_list;
+
 /* Idle thread. */
 static struct thread *idle_thread;
 
@@ -62,6 +65,7 @@ static void init_thread (struct thread *, const char *name, int priority);
 static void do_schedule(int status);
 static void schedule (void);
 static tid_t allocate_tid (void);
+static bool thread_tick_less (const struct list_elem *a, const struct list_elem *b, void *aux);
 
 /* Returns true if T appears to point to a valid thread. */
 #define is_thread(t) ((t) != NULL && (t)->magic == THREAD_MAGIC)
@@ -109,6 +113,7 @@ thread_init (void) {
 	lock_init (&tid_lock);
 	list_init (&ready_list);
 	list_init (&destruction_req);
+	list_init (&block_list);
 
 	/* Set up a thread structure for the running thread. */
 	initial_thread = running_thread ();
@@ -587,4 +592,36 @@ allocate_tid (void) {
 	lock_release (&tid_lock);
 
 	return tid;
+}
+
+
+void wait_thread(int64_t ticks) {
+	struct thread *current_t = thread_current();
+	current_t->wake_tick = ticks;
+
+	enum intr_level old_level = intr_disable();
+	/* timer 인터럽트에서 block_list를 체크하는 작업이 진행되기 때문에 
+		리스트에 넣고 현재 스레드를 block하는 작업이 원자적을 처리 되어야 하기 때문에
+		inter_disable과 intr_set_level의 스코프에 두개의 작업을 넣어준다. */
+	list_insert_ordered(&block_list, &current_t->elem, thread_tick_less, NULL);
+	thread_block();
+
+	intr_set_level(old_level);
+}
+
+void check_block_list(int64_t cur_ticks) {
+	struct thread *front;
+
+	while (!list_empty(&block_list) && (front = list_entry(list_front(&block_list), struct thread, elem)) 
+		&& front->wake_tick <= cur_ticks) {
+		list_pop_front(&block_list);
+		thread_unblock(front);
+	}
+}
+
+static bool thread_tick_less (const struct list_elem *a, const struct list_elem *b, void *aux) {
+	const struct thread *t_a = list_entry(a, struct thread, elem);
+	const struct thread *t_b = list_entry(b, struct thread, elem);
+
+	return t_a->wake_tick < t_b->wake_tick;
 }


### PR DESCRIPTION
## 연관이슈
- #38 

## 목적
- time_sleep 관련 로직들의 책임이 thread.c에 있는게 적절하다 판단하여 thread.c로 로직들을 옮기는 작업을 진행했습니다.

## 작업내용
- (timer.c)thread_elem 구조체, sleep_list 제거, (thread.c) block_list 추가
- (timer.c)thread 구조체에 wake_time 맴버 변수 추가
- (timer.c)timer_sleep(), timer_interrupt() 로직 (thread.c)wait_thread(), check_block_list() 함수로 이동