### PR TITLE
feat: priority sema 테스트 통과 기능 구현

### DIFF
--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -66,7 +66,7 @@ sema_down (struct semaphore *sema) {
 
 	old_level = intr_disable ();
 	while (sema->value == 0) {
-		list_push_back (&sema->waiters, &thread_current ()->elem);
+		list_insert_ordered(&sema->waiters, &thread_current()->elem, thread_priority_more, NULL);
 		thread_block ();
 	}
 	sema->value--;
@@ -109,10 +109,13 @@ sema_up (struct semaphore *sema) {
 	ASSERT (sema != NULL);
 
 	old_level = intr_disable ();
-	if (!list_empty (&sema->waiters))
-		thread_unblock (list_entry (list_pop_front (&sema->waiters),
-					struct thread, elem));
+	if (!list_empty (&sema->waiters)){
+		struct thread *sema_t = list_entry (list_pop_front (&sema->waiters),struct thread, elem);		
+		thread_unblock(sema_t);
+	}					
 	sema->value++;
+	//!!!! thread_yield()위치 생각해보자
+	thread_yield();
 	intr_set_level (old_level);
 }
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -274,9 +274,12 @@ thread_unblock (struct thread *t) {
 	intr_set_level (old_level);
 
 	struct thread *curr = thread_current();
-	if (curr != idle_thread && curr->priority < t->priority){
-		thread_yield();
-	}
+
+	// if (curr != idle_thread && curr->priority < t->priority){
+	// 	// printf("[debug] t priority: %d, thread_yield\n", t->priority);
+	// 	//! 여기
+	// 	thread_yield();
+	// }
 }
 
 /* Returns the name of the running thread. */
@@ -341,6 +344,7 @@ thread_yield (void) {
 	*/
 	if (curr != idle_thread)
 		list_insert_ordered(&ready_list, &curr->elem, thread_priority_more, NULL);
+	//!여기
 	do_schedule (THREAD_READY);
 	intr_set_level (old_level);
 }
@@ -528,6 +532,7 @@ thread_launch (struct thread *th) {
 	 * and then switching to the next thread by calling do_iret.
 	 * Note that, we SHOULD NOT use any stack from here
 	 * until switching is done. */
+	//! 여기
 	__asm __volatile (
 			/* Store registers that will be used. */
 			"push %%rax\n"
@@ -590,6 +595,7 @@ do_schedule(int status) {
 		palloc_free_page(victim);
 	}
 	thread_current ()->status = status;
+	//! 여기
 	schedule ();
 }
 
@@ -627,6 +633,7 @@ schedule (void) {
 
 		/* Before switching the thread, we first save the information
 		 * of current running. */
+		//! 여기
 		thread_launch (next);
 	}
 }


### PR DESCRIPTION
## 연관 이슈
#25 

## 작업 내용
- priority sema 테스트 통과를 위해 sema_up(), sema_down() 함수 로직을 수정했습니다.
- thread_unblock() 함수에서 잘못된 로직이였던 thread_yield() 로직을 제외했습니다.