### PR TITLE
Refactor/get program name

### DIFF
--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -32,6 +32,7 @@ static void process_cleanup (void);
 static bool load (const char *file_name, struct intr_frame *if_);
 static void initd (void *f_name);
 static void __do_fork (void *);
+static bool get_program_name (const char *cmdline, char *program_name, const size_t size);
 
 /* General process initializer for initd and other process. */
 static void
@@ -58,15 +59,35 @@ process_create_initd (const char *file_name) {
 
 	// 스레드 이름은 args 옵션을 뺀 실제 파일 이름이어야한다.
 	char actual_name[THREAD_NAME_MAX];
-	char *save_ptr;
-	strlcpy(actual_name, file_name, MIN(strlen(file_name) + 1, THREAD_NAME_MAX));
-	strtok_r(actual_name, " ", &save_ptr);
+
+
+	// char *save_ptr;
+	// strlcpy(actual_name, file_name, MIN(strlen(file_name) + 1, THREAD_NAME_MAX));
+	// strtok_r(actual_name, " ", &save_ptr);
+
+	get_program_name(file_name, actual_name, THREAD_NAME_MAX);
 
 	/* Create a new thread to execute FILE_NAME. */
 	tid = thread_create (actual_name, PRI_DEFAULT, initd, fn_copy);
 	if (tid == TID_ERROR)
 		palloc_free_page (fn_copy);
 	return tid;
+}
+
+/**
+ * cmdline은 쪼개야할 데이터를 받음
+ * program_name은 결과를 저장할 버퍼를 받음
+ * size는 버퍼 크기
+ * @author minmings111@gmail.com
+ * @date 2026-05-04
+ */
+static bool
+get_program_name (const char *cmdline, char *program_name, const size_t size){
+	char *save_ptr;
+	strlcpy(program_name, cmdline, MIN(strlen(cmdline) + 1, size));
+	strtok_r(program_name, " ", &save_ptr);
+
+	return save_ptr == NULL;
 }
 
 /* A thread function that launches first user process. */
@@ -356,15 +377,15 @@ load (const char *file_name, struct intr_frame *if_) {
 
 	// TODO: file_name bytes 제한
 	// 파일 이름 추출 - malloc
-	size_t file_name_len = 0, prefix_offset = 0;
-	while(file_name[0] == ' ') file_name++;
-	for(file_name_len = 0; file_name[file_name_len] != '\0' && file_name[file_name_len] != ' '; file_name_len++);
-	char *file_name_start = malloc(file_name_len + 1);
-	strlcpy(file_name_start, file_name, file_name_len + 1);
+
+	char file_name_start[THREAD_NAME_MAX];
+	// strlcpy(file_name_start, file_name, file_name_len + 1);
+
+	get_program_name(file_name, file_name_start, THREAD_NAME_MAX);
 
 	/* Open executable file. */
 	file = filesys_open (file_name_start);
-	free(file_name_start);
+	// free(file_name_start);
 	if (file == NULL) {
 		printf ("load: %s: open failed\n", file_name);
 		goto done;


### PR DESCRIPTION
## 변경 사항

- `process_create_initd()`와 `load()`에 중복되어 있던 실행 파일 이름 추출 로직을 `get_program_name()` helper로 분리했습니다.
- 전체 커맨드라인에서 첫 번째 토큰만 추출해 thread 이름 생성과 실행 파일 open 과정에서 재사용하도록 정리했습니다.

## 의도

argument passing 구현 과정에서 `"program arg1 arg2"` 형태의 입력을 다룰 때, 실행 파일 이름만 분리하는 로직이 여러 곳에 흩어져 있어 중복을 줄이고 `load()` 흐름을 더 명확하게 만들기 위한 리팩토링입니다.