### PR TITLE
fix: 지원하지 않는 write fd에 실패값 반환

### DIFF
--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -32,6 +32,7 @@ static void process_cleanup (void);
 static bool load (const char *file_name, struct intr_frame *if_);
 static void initd (void *f_name);
 static void __do_fork (void *);
+static bool get_program_name (const char *cmdline, char *program_name, const size_t size);
 
 /* General process initializer for initd and other process. */
 static void
@@ -58,15 +59,35 @@ process_create_initd (const char *file_name) {
 
 	// 스레드 이름은 args 옵션을 뺀 실제 파일 이름이어야한다.
 	char actual_name[THREAD_NAME_MAX];
-	char *save_ptr;
-	strlcpy(actual_name, file_name, MIN(strlen(file_name) + 1, THREAD_NAME_MAX));
-	strtok_r(actual_name, " ", &save_ptr);
+
+
+	// char *save_ptr;
+	// strlcpy(actual_name, file_name, MIN(strlen(file_name) + 1, THREAD_NAME_MAX));
+	// strtok_r(actual_name, " ", &save_ptr);
+
+	get_program_name(file_name, actual_name, THREAD_NAME_MAX);
 
 	/* Create a new thread to execute FILE_NAME. */
 	tid = thread_create (actual_name, PRI_DEFAULT, initd, fn_copy);
 	if (tid == TID_ERROR)
 		palloc_free_page (fn_copy);
 	return tid;
+}
+
+/**
+ * cmdline은 쪼개야할 데이터를 받음
+ * program_name은 결과를 저장할 버퍼를 받음
+ * size는 버퍼 크기
+ * @author minmings111@gmail.com
+ * @date 2026-05-04
+ */
+static bool
+get_program_name (const char *cmdline, char *program_name, const size_t size){
+	char *save_ptr;
+	strlcpy(program_name, cmdline, MIN(strlen(cmdline) + 1, size));
+	strtok_r(program_name, " ", &save_ptr);
+
+	return save_ptr == NULL;
 }
 
 /* A thread function that launches first user process. */
@@ -356,15 +377,15 @@ load (const char *file_name, struct intr_frame *if_) {
 
 	// TODO: file_name bytes 제한
 	// 파일 이름 추출 - malloc
-	size_t file_name_len = 0, prefix_offset = 0;
-	while(file_name[0] == ' ') file_name++;
-	for(file_name_len = 0; file_name[file_name_len] != '\0' && file_name[file_name_len] != ' '; file_name_len++);
-	char *file_name_start = malloc(file_name_len + 1);
-	strlcpy(file_name_start, file_name, file_name_len + 1);
+
+	char file_name_start[THREAD_NAME_MAX];
+	// strlcpy(file_name_start, file_name, file_name_len + 1);
+
+	get_program_name(file_name, file_name_start, THREAD_NAME_MAX);
 
 	/* Open executable file. */
 	file = filesys_open (file_name_start);
-	free(file_name_start);
+	// free(file_name_start);
 	if (file == NULL) {
 		printf ("load: %s: open failed\n", file_name);
 		goto done;

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -42,7 +42,7 @@ syscall_init (void) {
 void
 syscall_handler (struct intr_frame *f UNUSED) {
 	// TODO: Your implementation goes here.
-	uint64_t sys_num = f->R.rax;
+	uint64_t sys_num = f->R.rax; // 커널 진입시, 호출된 시스템콜이 무엇인지 확인하는 번호
 	uint64_t arg0 = f->R.rdi;
 	uint64_t arg1 = f->R.rsi;
 	uint64_t arg2 = f->R.rdx;
@@ -56,11 +56,21 @@ syscall_handler (struct intr_frame *f UNUSED) {
 		size_t buf_size = (size_t)arg2; // size
 		if(fd == 1) {
 			putbuf(buf, buf_size);
+			// 시스템콜 처리가 끝날 때는 같은 rax를 반환값 저장용으로 사용
+			f->R.rax = buf_size; // 사용한 바이트 수 만큼 리턴
+		}
+		else{
+			/**
+			 * 아무 값도 안 넣으면, rax에 기존 값이 그대로 남아 있어서
+			 * 사용자 프로그램은 write()의 반환값으로 시스템콜 번호 같은 
+			 * 엉뚱한 값을 받기 때문에 성공/실패 유무를 알 수 없고,
+			 * 기존값이 양수라면 성공했다고 오인 가능성이 있음
+			*/
+			 f->R.rax = -1; // 실패시 -1 리턴
 		}
 
-		// 사용한 바이트 수 만큼 리턴
-		f->R.rax = buf_size;
-	} else if(f->R.rax == SYS_EXIT) {
+		
+	} else if(sys_num == SYS_EXIT) {
 		thread_current()->exit_code = arg0;
 		thread_exit();
 	}


### PR DESCRIPTION
## 연관 이슈
#161 

## 변경 사항

- `SYS_WRITE` 처리에서 `fd == 1`인 경우에만 `putbuf()`를 호출하고, 실제로 출력한 바이트 수를 반환하도록 수정했습니다.
- 지원하지 않는 fd에 대해서는 성공값처럼 `buf_size`를 반환하지 않고 `-1`을 반환하도록 변경했습니다.
- 시스템콜 번호 비교 시 `f->R.rax`를 직접 다시 참조하지 않고, 초기에 저장한 `sys_num`을 사용하도록 정리했습니다.

## 배경

기존 구현에서는 `fd != 1`인 경우 실제 write를 수행하지 않았음에도 항상 `buf_size`를 반환할 수 있었습니다. 이 경우 사용자 프로그램이 write 성공으로 오인할 수 있어, 지원하지 않는 fd는 명확히 실패로 처리하도록 수정했습니다.

## 확인 사항

- 현재 `SYS_WRITE`는 stdout인 `fd == 1`만 지원합니다.
- 파일 디스크립터 테이블 기반 write 처리는 추후 구현 범위입니다.
