### PR TITLE
feat: halt

### DIFF
--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -15,6 +15,7 @@
 #include "userprog/fd.h"
 #include "threads/malloc.h"
 #include "threads/vaddr.h"
+#include "threads/init.h"
 
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
@@ -24,6 +25,7 @@ static void check_user_laddr (const void *buf, const size_t size);
 static bool is_valid_user_buffer (const void *buffer, size_t size);
 static bool check_file_name (const char *s);
 static int syscall_open (const char *file);
+static void syscall_halt ();
 
 /* System call.
  *
@@ -91,9 +93,12 @@ syscall_handler (struct intr_frame *f UNUSED) {
 			 f->R.rax = -1; // 실패시 -1 리턴
 		}
 		break;
-		case SYS_OPEN:
-			f->R.rax = syscall_open((const char *)arg0);
-			break;
+	case SYS_OPEN:
+		f->R.rax = syscall_open((const char *)arg0);
+		break;
+	case SYS_HALT:
+		power_off();
+		break;
 	case SYS_CREATE:
 		const char* file      = (const char*)arg0; // file
 		unsigned initial_size = (unsigned)arg1;    // initial_size


### PR DESCRIPTION
handle `halt` system call. 
Terminates Pintos by calling `power_off()` declared in `src/include/threads/init.h`.