### PR TITLE
refactor: wait semaphore insert `thread_create`로 옮김

### DIFF
--- a/pintos/threads/init.c
+++ b/pintos/threads/init.c
@@ -82,6 +82,7 @@ main (void) {
 	   then enable console locking. */
 	thread_init ();
 	console_init ();
+	init_process_status_list();
 
 	/* Initialize memory system. */
 	mem_end = palloc_init ();
@@ -242,7 +243,6 @@ run_task (char **argv) {
 
 	printf ("Executing '%s':\n", task);
 #ifdef USERPROG
-	init_process_status_list();
 	if (thread_tests){
 		run_test (task);
 	} else {

--- a/pintos/threads/init.c
+++ b/pintos/threads/init.c
@@ -82,7 +82,6 @@ main (void) {
 	   then enable console locking. */
 	thread_init ();
 	console_init ();
-	init_process_status_list();
 
 	/* Initialize memory system. */
 	mem_end = palloc_init ();
@@ -90,6 +89,7 @@ main (void) {
 	paging_init (mem_end);
 
 #ifdef USERPROG
+	init_process_status_list();
 	tss_init ();
 	gdt_init ();
 #endif

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -208,6 +208,10 @@ tid_t thread_create(const char *name, int priority,
     init_thread(t, name, priority);
     tid = t->tid = allocate_tid();
 
+    if (tid != TID_ERROR) {
+		child_status_insert(tid);
+	}
+
     /* Call the kernel_thread if it scheduled.
      * Note) rdi is 1st argument, and rsi is 2nd argument. */
     t->tf.rip = (uintptr_t)kernel_thread;

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -208,9 +208,11 @@ tid_t thread_create(const char *name, int priority,
     init_thread(t, name, priority);
     tid = t->tid = allocate_tid();
 
+#ifdef USERPROG
     if (tid != TID_ERROR) {
 		child_status_insert(tid);
 	}
+#endif
 
     /* Call the kernel_thread if it scheduled.
      * Note) rdi is 1st argument, and rsi is 2nd argument. */

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -79,9 +79,7 @@ process_create_initd (const char *file_name) {
 	tid = thread_create (actual_name, PRI_DEFAULT, initd, fn_copy);
 	if (tid == TID_ERROR) {
 		palloc_free_page (fn_copy);
-	} else {
-		child_status_insert(tid);
-	}
+	} 
 	
 	return tid;
 }


### PR DESCRIPTION
wait semaphore insert `thread_create`로 옮김
- 기존 코드에서는 thread_create 안 스레드가 unblock되면서 스케쥴링에 들어가기 때문에, `child_status_insert`가 수행되기 전 스레드가 끝나버리면, 무한 대기할 가능성이 있습니다. 이 현상을 막기위해 코드를 수정했습니다.